### PR TITLE
Updated pages' text to reflect Rebble's current progress

### DIFF
--- a/auth/templates/account-info.html
+++ b/auth/templates/account-info.html
@@ -118,7 +118,7 @@
             <a href="https://boot.rebble.io/">repeat the initial setup</a>. Don't worry: it only takes a minute.</p>
         <p>Do you want to undo the Rebble configuration process, removing it completely from your Pebble app? 
             You won't get access to the Rebble app store or any other Rebble services (including ones you've paid for!),
-            and it might erase some of your Pebble app data. If you have a paid subscription, this will not cancel it
+            until you re-do the setup process, and it might erase some of your Pebble app data. If you have a paid subscription, this will not cancel it
             for you. You'll need to cancel it using the button above. Still ready?
             Just click this link here: -------> <a href="pebble://custom-boot-config-url/default">De-Rebble-ify!</a>
     {% endif %}

--- a/auth/templates/account-info.html
+++ b/auth/templates/account-info.html
@@ -119,7 +119,7 @@
         <p>Do you want to undo the Rebble configuration process, removing it completely from your Pebble app? 
             You won't get access to the Rebble app store or any other Rebble services (including ones you've paid for!),
             until you re-do the setup process, and it might erase some of your Pebble app data. If you have a paid subscription, this will not cancel it
-            for you. You'll need to cancel it using the button above. Still ready?
+            for you. You'll need to cancel it using the button above. You might also need to try it multiple times for it to work. Still ready?
             Just click this link here: -------> <a href="pebble://custom-boot-config-url/default">De-Rebble-ify!</a>
     {% endif %}
 {% endblock %}

--- a/auth/templates/account-info.html
+++ b/auth/templates/account-info.html
@@ -116,5 +116,10 @@
             </form>
         <p>Are services you subscribed to not functioning? You might need to
             <a href="https://boot.rebble.io/">repeat the initial setup</a>. Don't worry: it only takes a minute.</p>
+        <p>Do you want to undo the Rebble configuration process, removing it completely from your Pebble app? 
+            You won't get access to the Rebble app store or any other Rebble services (including ones you've paid for!),
+            and it might erase some of your Pebble app data. If you have a paid subscription, this will not cancel it
+            for you. You'll need to cancel it using the button above. Still ready?
+            Just click this link here: -------> <a href="pebble://custom-boot-config-url/default">De-Rebble-ify!</a>
     {% endif %}
 {% endblock %}

--- a/auth/templates/logged-in.html
+++ b/auth/templates/logged-in.html
@@ -23,7 +23,7 @@
 <p>Also, note that if you have a Pebble Time or newer, you will be prompted to update to the 4.4.0-rbl
 firmware, which is a small bugfix that patches dictation not working in iOS 11 or newer.</p>
 <p>Also also, if you have a Pebble Classic or Pebble Steel that is on a very old firmware verison (pre-3.x), 
-    it's <strong>highly recommended</strong> you go through the setup process with your Pebble *before* you 
+    it's <strong>highly recommended</strong> you go through the setup process with your Pebble <strong>before</strong> you 
     Rebble-ify it. More details at <a href="http://rebble.io/howto">rebble.io/howto</a>.
      </p>
 {% endblock %}

--- a/auth/templates/logged-in.html
+++ b/auth/templates/logged-in.html
@@ -20,7 +20,9 @@
     <li>For those with subscriptions, <strong>dictation</strong> and <strong>weather</strong> are also available.</li>
     <li>Timeline support for third-party apps is not yet available, but is still planned.</li>
 </ul>
-<p>Also, note that if you are using a Pebble Time Round or Pebble 2 with an iOS 11 device, dictation did not work for
-    you before and probably still does not work for you now. We might have a fix for this, but it has not shipped
-    yet.</p>
+<p>Also, note that if you have a Pebble Time or newer, you will be prompted to update to the 4.4.0-rbl
+firmware, which is a small bugfix that patches dictation not working in iOS 11 or newer.</p>
+<p>Also also, if you have a Pebble Classic or Pebble Steel that is on a very old firmware verison (pre-3.x), 
+    it's <strong>highly recommended</strong> you go through the setup process with your Pebble *before* you 
+    Rebble-ify it. More details at <a href="http://rebble.io/howto">.
 {% endblock %}

--- a/auth/templates/logged-in.html
+++ b/auth/templates/logged-in.html
@@ -25,4 +25,6 @@ firmware, which is a small bugfix that patches dictation not working in iOS 11 o
 <p>Also also, if you have a Pebble Classic or Pebble Steel that is on a very old firmware verison (pre-3.x), 
     it's <strong>highly recommended</strong> you go through the setup process with your Pebble *before* you 
     Rebble-ify it. More details at <a href="http://rebble.io/howto">.
+    
+    </p>
 {% endblock %}

--- a/auth/templates/logged-in.html
+++ b/auth/templates/logged-in.html
@@ -24,7 +24,6 @@
 firmware, which is a small bugfix that patches dictation not working in iOS 11 or newer.</p>
 <p>Also also, if you have a Pebble Classic or Pebble Steel that is on a very old firmware verison (pre-3.x), 
     it's <strong>highly recommended</strong> you go through the setup process with your Pebble *before* you 
-    Rebble-ify it. More details at <a href="http://rebble.io/howto">.
-    
-    </p>
+    Rebble-ify it. More details at <a href="http://rebble.io/howto">rebble.io/howto</a>.
+     </p>
 {% endblock %}


### PR DESCRIPTION
Also added a de-Rebble button on the subscription status page that should revert the Pebble app back to its default config, and added a little warning about Rebble's known issues with setting up Classics and Steels on old firmware.