### PR TITLE
Add developerID to Wizard mode

### DIFF
--- a/auth/templates/wizard/user.html
+++ b/auth/templates/wizard/user.html
@@ -43,6 +43,17 @@
             </td>
         </tr>
         <tr>
+            <td>Developer ID</td>
+            <td>{{ user.pebble_dev_portal_uid }}</td>
+            <td>
+                <form action="{{ url_for(" wizard.user_modify ", id=user.id) }}" method="POST" style="display: inline;">
+                    <input type="text" name="pebble_dev_portal_uid" />
+                    <input type="submit" value="Change" />
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                </form>
+            </td>
+        </tr>
+        <tr>
             <td><span class="hoverable" title="This is how we identify your Rebble account, not by e-mail address.  If you expect to be subscribed and you're not, perhaps try a different way of logging in?">Log-in providers</span></td>
             <td>{% for identity in identities %} <a href="{{ url_for("wizard.useridentity_by_idp", id="%s:%s" % (identity.idp, identity.idp_user_id)) }}">{{ identity.idp }}:{{ identity.idp_user_id }}</a>{% if not loop.last %},<br>{% endif %}{% endfor %}
         </tr>
@@ -93,3 +104,4 @@
     </table>
 
 {% endblock %}
+

--- a/auth/wizard/__init__.py
+++ b/auth/wizard/__init__.py
@@ -98,6 +98,11 @@ def user_modify(id):
         old = user.email
         new = request.form['email']
         user.email = new
+    elif 'pebble_dev_portal_uid' in request.form:
+        what = 'developer ID'
+        old = user.pebble_dev_portal_uid
+        new = request.form['pebble_dev_portal_uid']
+        user.pebble_dev_portal_uid = new
     
     audit(f"MODIFICATION: Changed user {user.id} {what} from '{old}' to '{new}'")
     db.session.commit()


### PR DESCRIPTION
This PR is part of the update for the new developer portal.

It is standalone from the actual developer portal, and can be merged by itself. It simply adds the ability to update a Rebble user's developer ID.

This will be used by wizards to give Rebble users who did not migrate their account before the Pebble shutdown control of their old Pebble developer account.