### PR TITLE
chore: disable Facebook auth, add message for existing Facebook users

### DIFF
--- a/auth/login/facebook.py
+++ b/auth/login/facebook.py
@@ -1,4 +1,4 @@
-from flask import g
+from flask import render_template
 
 from ..models import db
 from .base import auth, login_blueprint, complete_auth_flow, secure_url_for, prepare_state, validate_state, get_state
@@ -17,23 +17,25 @@ facebook = auth.remote_app(
 
 @login_blueprint.route("/facebook")
 def facebook_auth_start():
-    prepare_state()
-    return facebook.authorize(secure_url_for('.facebook_auth_complete'))
+    # See #32 - Facebook auth disabled due to some weird Facebook issues.
+    # prepare_state()
+    # return facebook.authorize(secure_url_for('.facebook_auth_complete'))
+    return render_template('facebook-not-available.html')
 
 
-@login_blueprint.route("/facebook/complete")
-def facebook_auth_complete():
-    validate_state()
-    resp = facebook.authorized_response()
-    if resp is None or resp.get('access_token') is None:
-        return 'Failed.'
-    g.facebook_token = (resp['access_token'], '')
-    me = facebook.get('me?fields=id,name,email').data
-    response = complete_auth_flow(facebook.name, me["id"], me["name"], me.get('email',  None))
-    db.session.commit()
-    return response
+# @login_blueprint.route("/facebook/complete")
+# def facebook_auth_complete():
+#     validate_state()
+#     resp = facebook.authorized_response()
+#     if resp is None or resp.get('access_token') is None:
+#         return 'Failed.'
+#     g.facebook_token = (resp['access_token'], '')
+#     me = facebook.get('me?fields=id,name,email').data
+#     response = complete_auth_flow(facebook.name, me["id"], me["name"], me.get('email',  None))
+#     db.session.commit()
+#     return response
 
 
-@facebook.tokengetter
-def get_token():
-    return g.facebook_token
+# @facebook.tokengetter
+# def get_token():
+#     return g.facebook_token

--- a/auth/templates/facebook-not-available.html
+++ b/auth/templates/facebook-not-available.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block body %}
+    <h2>Facebook authentication is unavailable</h2>
+    <p>
+        Due to recent changes in Facebook's requirements, we can no longer provide Facebook authentication.
+    </p>
+    <p>
+        If you previously logged in using Facebook, please contact Rebble via <a href="mailto:support@rebble.io">email</a> or <a href="https://rebble.io/discord">our Discord server</a> for help getting back into your account.
+    </p>
+    <p><a href="/auth">Try logging in again.</a></p>
+{% endblock %}


### PR DESCRIPTION
This PR "disables" Facebook auth and adds a message to contact support whenever you click the "login" button. It appears to work locally, and with rws-compose. I haven't removed the Facebook auth code, on the chance we may want to enable it again in the future.

Also, in a separate branch ([`chore/3.12-upgrade`](https://github.com/blockarchitech/rebble-auth-py/tree/chore/3.12-upgrade)), I've upgraded all of the dependencies to Python 3.12-compatible versions. However, I haven't made a PR for this, as I don't feel comfortable doing that as I don't have a Stripe testing environment to test the new version of the `stripe` module with existing Stripe code.